### PR TITLE
Varios cambios pequeños

### DIFF
--- a/capitulos/cap1.tex
+++ b/capitulos/cap1.tex
@@ -12,7 +12,7 @@
 
 \section*{Introducción}
 
-El eje central de este capitulo se basa en la búsqueda de una representación compacta, para
+El eje central de este capítulo se basa en la búsqueda de una representación compacta, para
 distribuciones de probabilidad conjunta de la forma $p(\bm x | \bm\theta)$. Esto, con
 la intención de realizar inferencia sobre variables y aprendizaje de parámetros de manera
 eficiente. \NC{Mejorar intro, añadir discusión sobre inferencia y aprendizaje.}
@@ -31,7 +31,7 @@ El problema con esta expresión es la dificultad computacional subyacente al cá
 distribuciones condicionales de la forma $p(x_{t} |  x_1,\ldots, x_{t-1} )$
 cuando el número de variables incidentes $t$ aumenta.
 
-\NC{propiedades básicas del calculo de probabilidades (CI por ej.) al apéndice.}
+\NC{propiedades básicas del cálculo de probabilidades (CI por ej.) al apéndice.}
 No obstante, la representación (\ref{eq:regla_cadena}) reduce su complejidad en presencia de
 \index{independencia condicional} \textbf{independencia condicional}.
 
@@ -77,7 +77,7 @@ Todo DAG posee un \index{ordenamiento topológico} \textit{ordenamiento topológ
 los nodos de cualquier DAG pueden ser numerados de manera tal, que todo nodo padre
 posea una numeración inferior a sus nodos hijos. \NC{lema de ordenamiento topológico
 para DAG's en apéndice.} Esta característica permite enriquecer la formulación de la propiedad
-de Markov (\ref{eq:markov_prop}), usando la estructura grafica como componente adicional. De
+de Markov (\ref{eq:markov_prop}), usando la estructura gráfica como componente adicional. De
 esta forma, se puede formular la \index{propiedad ordenada de Markov} \textbf{propiedad ordenada
 de Markov} en modelos gráficos dirigidos:
 \begin{equation}
@@ -97,7 +97,7 @@ ordenada de Markov, se puede descomponer de la forma:
 p(\bm x ) = \prod_{t = 1}^{V} p(x_t  |  \bm x_{pa(t)})
 \end{equation}
 
-\begin{example}[Modelo grafico asociado a $p(\bm x)$]
+\begin{example}[Modelo gráfico asociado a $p(\bm x)$]
 Si se estudia un modelo probabilístico, donde la probabilidad conjunta de las variables
 estudiadas $p(\bm x)$ esta dada por:
 \begin{equation}
@@ -139,7 +139,7 @@ Si se usa este enfoque, se obtiene que la densidad condicional de clases toma la
 \end{equation}
 
 Al parametrizar las distribuciones de densidad condicional, es posible obtener un modelo de
-clasificación conocido como \index{clasificador naive Bayes}\textbf{clasificador naive Bayes}.
+clasificación conocido como \index{clasificador naive Bayes}\textbf{clasificador Naive Bayes}.
  La estructura de las relaciones de independencia inducidas por (\ref{eq:cond_nb}) se pueden
 expresar según (\ref{eq:naive_bayes}) y el modelo gráfico dirigido de la figura \ref{fig:naive_bayes}.
 
@@ -172,7 +172,7 @@ el representante $y_i$.
 \subfloat[]{\label{fig:plate_poly_graph_2}\input{./figuras/plate_poly_graph_2}}
 \quad
 \subfloat[]{\label{fig:plate_poly_graph_final}\input{./figuras/plate_poly_graph_final}}
-\caption{ Modelo grafico dirigido para regresión
+\caption{ Modelo gráfico dirigido para regresión
 polinomial usando notación de placas (o \textit{plates}). En \subref{fig:plate_poly_graph}
 se muestra el grafo correspondiente a (\ref{eq:poly_fact_1}). En \subref{fig:plate_poly_graph_2}
 se añaden los parámetros deterministas y las variables aleatorias observadas. En
@@ -218,7 +218,7 @@ El modelo gráfico dirigido que encapsula estas últimas ecuaciones se aprecia e
 
 \subsection{Modelos gráficos dirigidos gaussianos}
 
-Sea $\mathcal{M}$ un modelo grafico dirigido, en el cual todas las variables son
+Sea $\mathcal{M}$ un modelo gráfico dirigido, en el cual todas las variables son
 reales y sus distribuciones de probabilidad condicional son lineal-gaussianas:
 \begin{equation}
 	\label{eq:gaussian_cpd}
@@ -335,7 +335,7 @@ de las siguiente condiciones:
     o $e$ \textbf{no} es descendiente de algún elemento de $E$.
 \end{enumerate}
 
-Se dice que un conjunto de nodos $A$ esta d-separado de un conjunto de nodos $B$,
+Se dice que un conjunto de nodos $A$ está d-separado de un conjunto de nodos $B$,
 dado un conjunto de nodos $E$, si y solo si, todo camino no dirigido desde cada nodo
 de $A$ a cada nodo de $B$ esta d-separado por $E$.
 
@@ -417,7 +417,7 @@ y $copa(t)$ sus copadres \footnote{nodos que comparten hijos con $x_t$}. En la
 figura \ref{fig:grafo_ejemplo} se tiene por ejemplo $mb(5) = \lbrace x_6, x_1, x_3, x_4 \rbrace$.
 Según la propiedad global de Markov, la presencia de los nodos copadres no parece
 ser necesaria en primera instancia (la dependencia condicional debería recaer
-unicamente en los nodos padres), sin embargo, al definir $\bm x_{-t}$ como el
+únicamente en los nodos padres), sin embargo, al definir $\bm x_{-t}$ como el
 conjunto de nodos distintos a $x_t$, es posible observar que la probabilidad conjunta adquiere
 la forma $p(\bm x) = p(x_t , \bm x_{-t})$. De donde, al marginalizar sobre el
 nodo $x_t$, se obtiene que $p(\bm x_{-t})$ contiene sólo a aquellos nodos del modelo

--- a/capitulos/cap2.tex
+++ b/capitulos/cap2.tex
@@ -64,37 +64,37 @@ una distribución estacionaria $\pi$ si:
 	\pi ( y ) = \int \pi ( x ) K ( x , y ) d x
 \end{equation}
 
-Una cadena de MArkov se dice irreductible, si puede transitar desde
+Una cadena de Markov se dice irreductible, si puede transitar desde
 cualquier estado $x$ de un espacio de estado discreto a cualquier otro
-estado $y$ en un numero finito de pasos, es decir, si existe $t$ tal que
+estado $y$ en un número finito de pasos, es decir, si existe $t$ tal que
 $K_{xy}^n > 0$. Si una cadena con distribución estacionaria es irreductible,
-la distribución estacionaria es unica y la cadena se dice recurrente
+la distribución estacionaria es única y la cadena se dice recurrente
 positiva. Una cadena recurrente positiva, aperiodica con distribución
 estacionaria $\pi$, cumple para toda distribución inicial $\lambda$ sobre
 sus estados:
 \begin{equation}
 	\lim _ { n \rightarrow \infty } \left\| \lambda K ^ { n } - \pi \right\| = 0
 \end{equation}
-donde $K$ es el operado (o matriz) de transición. Para cadenas de Markov
+donde $K$ es el operador (o matriz) de transición. Para cadenas de Markov
 irreductibles con una única distribución estacionaria $\pi$, según la ley de los grandes números se debe cumplir que el valor esperado de una función $g(x)$ sobre $\pi$ verifica:
 \begin{equation}
 	\mathbb{E} _ { \pi } [ g ( x ) ] = \int g ( x ) \pi ( x ) d x = \lim _ { n \rightarrow \infty } \frac { 1 } { n } \sum _ { i = 1 } ^ { n } g \left( x _ { i } \right)
 \end{equation}
 
-Esta propiedad permite estimar calcular aproximaciones de cantidades especificas de interés a partir de una cadena de Markov. Los algoritmos que utilizan tal resultado se conoce como métodos MCMC.
+Esta propiedad permite estimar calcular aproximaciones de cantidades específicas de interés a partir de una cadena de Markov. Los algoritmos que utilizan tal resultado se conoce como métodos MCMC.
 
-Una cadena con distribución estacionara $\pi$ se dice reversible si el par $(x_t,x_{t+1})$ tiene la misma distribución conjunta que $(x_{t+1},x_{t})$. En terminos del operador de transición $K$, esto se traduce como
+Una cadena con distribución estacionaria $\pi$ se dice reversible si el par $(x_t,x_{t+1})$ tiene la misma distribución conjunta que $(x_{t+1},x_{t})$. En términos del operador de transición $K$, esto se traduce como
 \begin{equation}
 \pi \left( x _ { t } \right) K \left( x _ { t } , x _ { t + 1 } \right) = \pi \left( x _ { t + 1 } \right) K \left( x _ { t + 1 } , x _ { t } \right)
 \end{equation}
 
 Una cadena de Markov no necesariamente debe ser reversible para poseer una
 distribución estacionaria. Sin embargo, la reversibilidad de una cadena,
-garantiza la existencia de una distribución estacionaria. Esta es la razon
-por la cual se busca que en la mayoria de los algotimos MCMC se cumpla esta
+garantiza la existencia de una distribución estacionaria. Esta es la razón
+por la cual se busca que en la mayoría de los algoritmos MCMC se cumpla esta
 propiedad (\textit{balance detallado}).
 
-\section{Algorimo Metropolis Hastings (MH)}
+\section{Algoritmo Metropolis Hastings (MH)}
 
 El algoritmo canónico MCMC se conoce como Metropolis-Hastings. Su
 formulación pasa por obtener muestras de una distribución $p(x)$ en un
@@ -139,7 +139,7 @@ pesadas.
 
 \subsection{Metropolis simétrico}
 
-Seleccionando  $q(y | x) = q(x|y)$, esta opción simplica la probabilidad de aceptación a $\min \{ 1 , f ( y ) / f ( x ) \}$.
+Seleccionando  $q(y | x) = q(x|y)$, esta opción simplifica la probabilidad de aceptación a $\min \{ 1 , f ( y ) / f ( x ) \}$.
 
 \section{Muestreo de Gibbs}
 
@@ -180,7 +180,7 @@ De donde al integrar en ambos lados
 \end{equation}
 
 Luego, $p$ es la distribución estacionaria de la cadena de Markov formada
-por el kernel de transición $K(x{t+1}|x_t)$. El método de muestreo de Gibbs con el kernel propuesto no es reversible. Otra caracterisitca de este método, es que puede verse como un caso especial del metodo MH con coeficiente de aceptacion $\min \left( 1 , \frac { p ( y ) q ( x | y ) } { p ( x ) q ( y | x ) } \right) = 1$, de esto, al observar $\bm{y}_{-i} = \bm{x}_{-i}$ se tiene:
+por el kernel de transición $K(x{t+1}|x_t)$. El método de muestreo de Gibbs con el kernel propuesto no es reversible. Otra característica de este método, es que puede verse como un caso especial del metodo MH con coeficiente de aceptación $\min \left( 1 , \frac { p ( y ) q ( x | y ) } { p ( x ) q ( y | x ) } \right) = 1$, de esto, al observar $\bm{y}_{-i} = \bm{x}_{-i}$ se tiene:
 
 \begin{align}
 	p ( \bm{y} ) q ( \bm{x} | \bm{y} ) & = p \left( y _ { i } | \bm{y}_{- i} \right) p \left( \bm{y} _ { - i } \right) p \left( x _ { i } | \bm{y} _ { - i } \right) = p \left( y _ { i } | \bm{x} _ { - i } \right) p \left( \bm{x} _ { - i } \right) f \left( \bm{x} _ { i } | \bm{x} _ { - i } \right) \\
@@ -199,7 +199,7 @@ MWG (Metropolis within Gibbs).
 Si bien la formulación de los algoritmos MCMC estudiados hasta el momento
 garantizan convergencia a la distribución que se desea muestrear, no se
 especifica a priori el número de iteraciones necesarias para alcanzar esta
-convergencia. Para abordar este problema se estudian esquemas de diagnostico
+convergencia. Para abordar este problema se estudian esquemas de diagnóstico
 capaces de detectar fallas en la convergencia en este tipo de algoritmos.
 
 \subsection{Tamaño efectivo de muestra}
@@ -212,9 +212,9 @@ incertidumbre $\sigma_{x}$, es necesario obtener alrededor de $n=1000$
 muestras.
 
 Debido a la correlación existente en los puntos de una cadena MCMC, el
-calculo anterior no se verifica (las muestras no son independientes). No
-obstante, es posible medir que tan correlacionados están
-estos punto entre si, por medio del calculo de la autocorrelación, esta se
+cálculo anterior no se verifica (las muestras no son independientes). No
+obstante, es posible medir qué tan correlacionados están
+estos punto entre si, por medio del cálculo de la autocorrelación, esta se
 define por:
 \begin{equation}
 	\rho _ { x x } ( t ) = \frac { \mathbb { E } \left[ \left( x _ { i } - \overline { x } \right) \left( x _ { i + t } - \overline { x } \right) \right] } { \mathbb { E } [ \left( x _ { i } - \overline { x } \right) ^ { 2 } ] }
@@ -235,10 +235,10 @@ la correlación  integrada obteniéndose:
 
 De esta forma, para muestras correlacionadas, la varianza pasa a ser $2 ~
 \tau _ {int,x}$ veces mayor con respecto a la variancia sobre muestras
-independientes. Usando $\tau _ {int,x}$ es posible medir el \textit{numero
+independientes. Usando $\tau _ {int,x}$ es posible medir el \textit{número
 efectivo} de muestras independientes en una cadena correlacionada calculado
 $n/(2 ~ \tau _ {int,x})$ para luego usar esta cantidad para decidir si la
-cantidad de muestras es suficiente, en el caso de la media se busca como heurística un numero efectivo de muestras mayor a 1000.
+cantidad de muestras es suficiente, en el caso de la media se busca como heurística un número efectivo de muestras mayor a 1000.
 
 \subsection{Varianza entre cadenas}
 
@@ -286,7 +286,7 @@ de dimensionalidad extremadamente alta, los algoritmo tradicionales MCMC
 comienzan a presentar problemas. La formulación HMC (Monte Carlo
 Hamiltoniano) introduce una variable auxiliar de \textit{momentum} $u$ para
 para cada variable $x$. La distribución log posterior $\pi(x)$ se considera
-como el potencial de energia $U(x) = -\ln \pi(x)$ donde el momentum define
+como el potencial de energía $U(x) = -\ln \pi(x)$ donde el momentum define
 la energía cinética $K(u)$. De esta forma se define el \textit{Hamiltoniano} $H(x,u) = U(x) + K(u)$, donde $K(u) = u^2/2$. La distribución a explorar corresponde a
 
 \begin{equation}
@@ -307,8 +307,8 @@ por el usuario.
 
 \section{Inferencia variacional}
 
-En esta sección, se estudia un método de aproximación de distribucioness
-conocido como inferencia variacional (\textbf{VI} por sus siglas en ingles).
+En esta sección, se estudia un método de aproximación de distribuciones
+conocido como inferencia variacional (\textbf{VI} por sus siglas en inglés).
 En general, la aproximación por inferencia variacional tiende a ser más rápida y fácil de
 escalar a datos de gran tamaño en comparación al muestreo por \textbf{MCMC}. Por tal motivo, se ha hecho presente en análisis de documentos
 a gran escala y problemas de neurociencia computacional.
@@ -331,7 +331,7 @@ ve regulada por la estructura $\mathcal{Q}$. Por tanto, se busca modelar $\mathc
 La idea clave tras el proceso de aproximación por inferencia variacional,
 pasa por resolver su problema de optimización subyacente. Desde este punto
 de vista, $\mathcal{Q}$ se puede escoger como una familia de funciones
-parametrizadas, por tanto, el problema de encontrar la función optima
+parametrizadas, por tanto, el problema de encontrar la función óptima
  $q^* (\cdot)$ se transforma en encontrar los parámetros que la caracterizan. Para definir esta optimalidad, en la aproximación, se utiliza la divergencia de \textit{Kullback Leibler} ($\mathtt{KL}$), dada por:
 
 \begin{equation}
@@ -342,26 +342,26 @@ parametrizadas, por tanto, el problema de encontrar la función optima
 La densidad variacional obtenida de esta forma, sirve para representar la densidad condicional exacta.
 
 En el contexto inicial, si $\bm{x} = x_1, \ldots, x_n$ es un conjunto de variables observadas y $\bm{z}=z_1, \ldots, z_m$ variables latentes, con
-densidad conjunta $p(\bm{z},\bm{x})$. El problema de inferencia, cosiste en calcular la densidad condicional de las variables latentes dadas las observaciones, $p(\bm{z}|\bm{x})$, esta se puede escribir como:
+densidad conjunta $p(\bm{z},\bm{x})$. El problema de inferencia, consiste en calcular la densidad condicional de las variables latentes dadas las observaciones, $p(\bm{z}|\bm{x})$, esta se puede escribir como:
 
 \begin{equation}
 		p(\bm{z}|\bm{x})=\frac{p(\bm{z},\bm{x})}{p(\bm{x})}.
 \end{equation}
 
-Donde el denominador contiene la densidad marginal de las observaciones, también llamada la \textit{evidencia}. Al marginalizar sobre las variables latentes, se obtiene
+Donde el denominador contiene la densidad marginal de las observaciones, también llamada la \textit{evidencia}. Al marginalizar sobre las variables latentes, se obtiene:
 
 \begin{equation}
 		\label{eq:3_a}
 		p(\bm{x})=\int{p(\bm{z},\bm{x})d\bm{z}}.
 \end{equation}
-La dificultad de este proceso, recae en el calculo de esta integral, pues por lo general no se tiene su forma cerrada o se requiere de recursos computacionales prohibitivos para obtenerla. A modo de ejemplo se estudia el siguiente modelo:
+La dificultad de este proceso, recae en el cálculo de esta integral, pues por lo general no se tiene su forma cerrada o se requiere de recursos computacionales prohibitivos para obtenerla. A modo de ejemplo se estudia el siguiente modelo:
 
 \subsection{GMM Bayesiano I}
 
 Se considera un \textbf{GMM} (modelo de mezcla de Gaussianas)  de $C$ componentes, univariado y de varianza unitaria. Cada una de sus componentes
 corresponden a distribuciones Gaussianas con medias $\bm{\mu} = \left\{\mu_1,\dots,u_C\right\}$.
 
-Los parámetros correspondientes a las medias se obtienen independientemente según su distribución prior $p(\mu_k)$, que se supondrá $\mathcal{N}(0,\sigma^2)$, donde la varianza prior $\sigma^2$ corresponde a un hiperparámetro.
+Los parámetros correspondientes a las medias se obtienen independientemente según su distribución prior $p(\mu_k)$, que se supondrá $\mathcal{N}(0,\sigma^2)$, donde la varianza prior $\sigma^2$ corresponde a un híperparámetro.
 
 Para generar una observación $x_i$ del modelo, es necesario generar una
 asignación de cluster, esta se denota por $c_i$ e indica de qué cluster
@@ -390,14 +390,14 @@ En este modelo, las variables latentes corresponden a $\bm{z} = \left\{\bm{\mu},
 		\label{eq:8}
 		p(\bm{x})=\int{p(\bm{\mu})\displaystyle\prod_{i=1}^{n}\sum_{c_i}p(c_i)p(x_i|c_i,\bm{\mu})}d\bm{\mu}.
 \end{equation}
-El integrando en la ecuación (\ref{eq:8}) no se puede reduir a un producto de integrales unidimensionales sobre los $\mu_k$. Más aún, la complejidad del tiempo de evaluar numéricamente esta integra $C$-dimensional es $\mathcal{O}(k^n)$.
+El integrando en la ecuación (\ref{eq:8}) no se puede reducir a un producto de integrales unidimensionales sobre los $\mu_k$. Más aún, la complejidad del tiempo de evaluar numéricamente esta integra $C$-dimensional es $\mathcal{O}(k^n)$.
 
 Si por otra parte, se distribuye el producto sobre la suma en (\ref{eq:8}), es posible escribir la evidencia como:
 
 \begin{equation}
 		p(\bm{x})=\sum_{\bm{c}}p(\bm{c})\int{p(\bm{\mu})\displaystyle\prod_{i=1}^{n}p(x_i|c_i,\bm{\mu})}d\bm{\mu}.
 \end{equation}
-Donde debido a la conjugación entre las distribuciones (prior gaussiana), cada integral individual pasa a ser computable. Sin embargo, se deben calcular $k^n$ integrales de este tipo: una para cada configuración de las asignaciones de cluster. El calculo de la evidencia permanece exponencial en $C$ y por tanto intratable.
+Donde debido a la conjugación entre las distribuciones (prior gaussiana), cada integral individual pasa a ser computable. Sin embargo, se deben calcular $k^n$ integrales de este tipo: una para cada configuración de las asignaciones de cluster. El cálculo de la evidencia permanece exponencial en $C$ y por tanto intratable.
 
 \section{Cota inferior para la evidencia}
 
@@ -437,7 +437,7 @@ Es decir, se requiere calcular la evidencia $\log{p (\bm{x})}$, que como se comp
 		\mathtt{\mathtt{ELBO}}(q)=\mathbb{E}\left[\log{p(\bm{z,\bm{x}})}\right]-\mathbb{E}\left[\log{q(\bm{z})}\right].
 \end{equation}
 
-Esta función se denomina cota inferior para la evidencia (\textbf{ELBO} por sus siglas en ingles). De su definición, se observa que $\mathtt{ELBO}(q) = \log{p(\bm{\bm{x}})} - \mathtt{KL}(q(\bm{z})||p(\bm{z}|\bm{x})) $. Cabe
+Esta función se denomina cota inferior para la evidencia (\textbf{ELBO} por sus siglas en inglés). De su definición, se observa que $\mathtt{ELBO}(q) = \log{p(\bm{\bm{x}})} - \mathtt{KL}(q(\bm{z})||p(\bm{z}|\bm{x})) $. Cabe
 destacar, que ${p(\bm{x})}$, es una constante con respecto a $q (\bm{z})$.
 
 Según lo anterior, maximizar la cota $\mathtt{ELBO}$ es equivalente a
@@ -469,10 +469,10 @@ El resultado buscado se obtiene al observar que $\mathtt{KL} (\cdot) \geq 0$.
 \section{Familia variacional mean-field}
 
 En cuanto a la familia $\mathcal{Q}$ sobre la cual se busca aproximar, es necesario que su complejidad de sus complejidad permita resolver el problema
-de optimización subyacente. En esta contexto,  se estudia la familia
+de optimización subyacente. En este contexto, se estudia la familia
 variacional \textit{mean-field}, la cual se define de manera tal que las
 variables latentes son mutuamente independientes, cada una gobernada por un
-parametro distinto en la densidad variacional. Por tanto, si $q \in \mathcal{Q}$ entonces $q(\cdot)$ se podrá expresar como:
+parámetro distinto en la densidad variacional. Por tanto, si $q \in \mathcal{Q}$ entonces $q(\cdot)$ se podrá expresar como:
 
 \begin{equation}
 		\label{eq:15}
@@ -496,7 +496,7 @@ Al modelo GMM bayesiano del ejemplo anterior, se agrega una familia variacional 
 \end{equation}
 
 En este caso,  el factor $q (\mu_k; m_k, s^2_k)$ se modela como una
-distribución gaussiana en la componente $k$-esima con media
+distribución gaussiana en la componente $k$-ésima con media
 $m_k$ y varianza es $s^2_k$. El factor $q(c_i;\varphi_i)$ corresponde a una
 distribución para la $i$-ésima asignación cluster y por tanto, sus
 probabilidades de asignación corresponden a un vector $C$-dimensional
@@ -512,7 +512,7 @@ $\mathtt{ELBO}$ y una familia mean-field adecuada, establecer el problema de
 inferencia variacional y obtener su formulación como un problema de
 optimización. En esta sección, se describe el algoritmo de
 \textbf{inferencia variacional mean-field de coordenadas ascendentes}
-($\mathtt{CAVI}$ por sus siglas en ingles), el cual permite resolver tal
+($\mathtt{CAVI}$ por sus siglas en inglés), el cual permite resolver tal
 problema de optimización.El algoritmo $\mathtt{CAVI}$ optimiza
 iterativamente cada factor de la densidad variacional mean-field, mientras
 mantiene los demás fijos.
@@ -529,15 +529,15 @@ que el factor óptimo $q^{*}_j (z_j)$ verifica,
 El valor esperado en la ecuación (\ref{eq:17}) se calcula con respecto la
 densidad variacional de las variables $\bm{z}_{-j}$ para todo $j = 1,
 \ldots,m$, esta a su vez se expresa como $\prod_{\ell \neq j} q_\ell (z _\ell)$,
-de esta forma, se pueden incluir las variables $\bm{z}_{-j}$ al calculo de
-la probabilidad condicional y excluir del calculo del valor esperado $\mathbb{E}_j$. Por tal motivo, se verifica la siguiente relación de proporcionalidad (sobre la conjunta):
+de esta forma, se pueden incluir las variables $\bm{z}_{-j}$ al cálculo de
+la probabilidad condicional y excluir del cálculo del valor esperado $\mathbb{E}_j$. Por tal motivo, se verifica la siguiente relación de proporcionalidad (sobre la conjunta):
 \begin{equation}
 		\label{eq:18}
 		q_j^*(z_j)\propto \text{exp}\left\{\mathbb{E}_{-j}\left[\log{p(\bm{z}_j,z_{-j},\bm{x})}\right]\right\}.
 \end{equation}
 
 Debido a que todas las variables latentes son consideradas independientes
-(hipotesis mean-field) los valores esperados del lado derecho no involucran
+(hipótesis mean-field) los valores esperados del lado derecho no involucran
 al $j$-ésimo factor variacional. Por tanto la ecuación anterior, permite
 actualizar los factores (coordenadas) de manera iterativa. A continuación se
 presenta este algoritmo:
@@ -545,7 +545,7 @@ presenta este algoritmo:
 \DontPrintSemicolon
 \KwIn{Modelo $p(\bm{x},\bm{z})$ con datos $\bm{x}$}
 \KwOut{Densidad variacional $\prod_{j=1}^{m} q_j(z_j)$}
-\textbf{Inicializar}: Factores variacionels $q_j{(z_j)}$\;
+\textbf{Inicializar}: Factores variacionales $q_j{(z_j)}$\;
 \While{$\mathtt{ELBO}$ no converge}{
 			\For{$j = 1, \ldots, m$}{
 				Calcular $q_j^*(z_j)\propto \text{exp}\left\{\mathbb{E}_{-j}\left[\log{p(\bm{z}_j|z_{-j},\bm{x})}\right]\right\}$
@@ -667,7 +667,7 @@ $\varphi_{ik} = \mathbb{E} [c_{ik}; \varphi_i]$, luego
 \nonumber & = \left(\sum_i \varphi_{ik}x_i\right)\mu_k-\left(1/2\sigma^2+\sum_i\varphi_{ik}/2\right)\mu^2_k+\text{const.}
 \end{align}
 
-El cálculo anterior muestra que la densidad variacional optima por
+El cálculo anterior muestra que la densidad variacional óptima por
 coordenada de $\mu_k$ corresponde a una familia exponencial con estadísticos
 suficientes ${\mu _k, \mu 2 _k}$ y parámetros $\left\{\sum_{i=1}^n
 \varphi_{ik}x_i -1/2\sigma^2-\sum_{i=1}^n\varphi_{ik}/2\right\}$, es decir,
@@ -678,7 +678,7 @@ variacionales, las reglas de actualización para $q _(\mu k)$ son
 		m_k=\frac{\sum_i \varphi_{ik}x_i}{1/\sigma^2+\sum_i \varphi_{ik}}, & s^2_k=\frac{1}{1/\sigma^2+\sum_i \varphi_{ik}}
 \end{eqnarray}
 
-Estas reglas se relacionan fuertemente con la densisdad condicional completa
+Estas reglas se relacionan fuertemente con la densidad condicional completa
 de la para la $k$-ésima componente del modelo. La condicional completa es
 una gaussiana posterior dados los datos asignados a la $k$-ésima componente.
 La actualización variacional corresponde a una condicional completa
@@ -700,7 +700,7 @@ medias de cluster con sus medias variacionales $m _k$.
 
 \begin{algorithm}
 \DontPrintSemicolon
-\KwIn{Datos $x_1,\ldots,x_n$, numero de componentes $C$, varianza prior para las medias de las componentes $\sigma^2$}
+\KwIn{Datos $x_1,\ldots,x_n$, número de componentes $C$, varianza prior para las medias de las componentes $\sigma^2$}
 \KwOut{Densidades variacionales $q(\mu_k;m_k,s_k^2)$ y $q(c_i,\varphi_i)$}
 \textbf{Inicializar}: $\bm{m}= m_1, \ldots m_k$, $\bm{s}^2=s_1 \ldots s_k$, $\bm{\varphi} = \varphi_1, \ldots, \varphi_n$\;
 \While{$\mathtt{ELBO}$ no converge}{
@@ -736,7 +736,7 @@ chi-cuadrado, beta, ...) han sido ampliamente estudiadas y poseen propiedades
 interesantes en cuanto a conjugación prior-posterior, entre otras. Los
 modelos cuyas distribuciones condicionales completas pertenecen a esta
 familia de distribuciones presentan grandes ventajas en cuando a al
-aproximación por medio de inferncia variacional. En esta sección se estudian
+aproximación por medio de inferencia variacional. En esta sección se estudian
 tales propiedades.
 
 \subsection{Condicionales completas en familias exponenciales}
@@ -752,7 +752,7 @@ base, y $ a (\cdot)$ es el log normalizador. Debido a que esta es una
 densidad condicional, el parámetro $\eta _j (\bm{z} _{- j}, \bm{x})$ es una
 función del conjunto condicionante.
 
-En este contexto, la inferencia variacional por medio de dsitribuciones
+En este contexto, la inferencia variacional por medio de distribuciones
 mean-field pasa por ajustar $ q (\bm{z}) = \prod_j q_j (z_j) $. Al suponer
 pertenencia a la familia exponencial, se simplifica la actualización de coordenadas de la ecuación (\ref{eq:17}), en efecto:
 \begin{align}
@@ -776,7 +776,7 @@ de la condicional completa:
 		\nu _j= \mathbb{E}\left[\eta_j(\bm{z}_{-j},\bm{x})\right].
 \end{equation}
 
-Esta transformación permite simplificar los calculos necesarios para
+Esta transformación permite simplificar los cálculos necesarios para
 implementar $\mathtt{CAVI}$.
 
 \subsection{Conjugación condicional y modelos bayesianos}
@@ -799,7 +799,7 @@ corresponden a las componentes de mezcla y la $i$-ésima variable local es la
 asignación de cluster para el dato $x_i$.
 
 En el modelo de la ecuación (\ref{eq:41}) se supondrá, que los términos que
-la componen  hacen que cada condicional completa pertenesca a la familia
+la componen  hacen que cada condicional completa pertenezca a la familia
 exponencial. Para ello, se supondrá que la densidad conjunta
 de cada par $(x_i, z_i)$, condicional a $\beta$, tiene una forma de familia
 exponencial,
@@ -845,7 +845,7 @@ variacional global. El cual posee la misma densidad de familia exponencial
 que la prior. De forma similar, sea $q (z _i | \varphi _i)$ la distribución
 variacional posterior en cada variable local, en este caso, cada $z_i$ rije
 por un parámetro local variacional $\varphi_i$. Este posee la misma densidad
-de familia exponencial que el condicional local completo. El algotitmo
+de familia exponencial que el condicional local completo. El algoritmo
 $\mathtt{CAVI}$ itera entre la actualización de cada parámetro variacional
 local y la actualización del parámetro variacional global.
 La actualización variacional local es
@@ -902,7 +902,7 @@ se ajustan los parámetros globales actuales de una manera apropiada.
 
 \subsection{Gradiente natural de $\mathtt{ELBO}$}
 
-En la optimización basada en gradiente, el termino \textit{gradiente natural}
+En la optimización basada en gradiente, el término \textit{gradiente natural}
 toma en cuenta la estructura geométrica de los parámetros de probabilidad.
 Específicamente, los gradientes naturales deforman el espacio de parámetros
 de una manera sensible, de modo que mover la misma distancia en diferentes
@@ -916,7 +916,7 @@ métrica Riemanniana inversa y la matriz de información Fisher inversa.
 
 Los modelos conjugados condicionalmente poseen gradientes naturales
 simples para la cota $\mathtt{ELBO}$. Para gradientes con respecto al
-parámetro global $\lambda$ se conoce la formula del gradiente euclidiano de $\mathtt{ELBO}$:
+parámetro global $\lambda$ se conoce la fórmula del gradiente euclidiano de $\mathtt{ELBO}$:
 
 \begin{equation}
 		\nabla_\lambda\mathtt{ELBO}=a''(\lambda)(\mathbb{E}_\varphi[\hat\alpha]-\lambda),
@@ -928,9 +928,9 @@ donde $\mathbb{E}_\varphi [\hat\alpha]$ está en la ecuación (\ref{eq:48}). Pre
 		g(\lambda)=\mathbb{E}_\varphi[\hat\alpha]-\lambda.
 \end{equation}
 
-La cual es la diferencia entre las actualizaciones de coordenadas $E_\varphi [\hat\alpha]$ y los parámetros variacionales $\lambda$ en los que se evalua el gradiente.
+La cual es la diferencia entre las actualizaciones de coordenadas $E_\varphi [\hat\alpha]$ y los parámetros variacionales $\lambda$ en los que se evalúa el gradiente.
 
-Es posible usar este gradiente natural en un algoritmo de optimización basad
+Es posible usar este gradiente natural en un algoritmo de optimización basado
 en gradiente. Donde en cada iteración, se actualizan los parámetros globales,
 \begin{equation}
 		\lambda_t=\lambda_{t-1}+\epsilon_t g(\lambda_{t-1}),

--- a/capitulos/cap3.tex
+++ b/capitulos/cap3.tex
@@ -8,7 +8,7 @@
   %$\tilde{ \mathbf { K } } = \bm{K}_{*} - \bm{O}_{*}\bm{K}_{*} - \bm{K}_{*}\bm{O}_{*} + \bm{O}_{*}\bm{K}_{*}\bm{O}_{*}$\;
   %
   %$Z = \tilde{ \mathbf { K } } \bm{V}(:,1:L)$;
-\section{Introducción}
+\section*{Introducción}
 
 Un kernel es una función simétrica y definida positiva $k(\cdot,\cdot)$ que
 puede ser entendida como una medida de similitud entre los argumentos que opera.
@@ -32,9 +32,9 @@ restringirse a los reales, para ciertas aplicaciones puede ser conviene utilizar
 los complejos. En general las propiedades de interés se preservan en ambos cuerpos,
 por lo que por simplicidad se considera solo el caso real en esta monografía.}.
 Dentro de tal clase de funciones, son de importancia a aquellas capaces de ``generalizar"
-el concepto de \textit{porducto interno}, el \index{Teorema de Mercer}
+el concepto de \textit{producto interno}, el \index{Teorema de Mercer}
 \textbf{Teorema de Mercer} permite identificar tal subconjunto.
-\NC{Agregar apéndice sobre Teoria de Medida + integrar respecto a una medida
+\NC{Agregar apéndice sobre Teoría de Medida + integrar respecto a una medida
 learning with Kernels}
 \begin{theorem}[Teorema de Mercer]
 \label{mercer}
@@ -71,7 +71,7 @@ $\Phi: \mathcal{X} ~ \rightarrow ~ l_2^{N_{\mathcal{H}}}$ tal que
 $x ~ \mapsto ~ (\sqrt{\lambda_j} \psi_j(x))_{j=1,\ldots,N_{\mathcal{H}}}$, es decir,
 a cada elemento de $\mathcal{X}$ se le asocia una transformación por medio de las
 funciones propias asociadas a $k(\cdot,\cdot)$ al espacio $l_2^{N_{\mathcal{H}}}$.
-Este último espacio esta provisto de producto interno, por lo que es posible expresar
+Este último espacio está provisto de producto interno, por lo que es posible expresar
 $k(x,x') = \langle  \Phi(x), \Phi(x') \rangle_{l_2^{N_{\mathcal{H}}}}$ para casi todo $x \in \mathcal{X}$.
 Esto permite interpretar a $\Phi$ como una aplicación a un espacio de \textit{características},
 más aún, en este espacio $k(\cdot,\cdot)$ actúa como un producto interno, esto se
@@ -157,7 +157,7 @@ de funciones.
 
 \begin{definition}[Espacio de Hilbert con Kernel Reproductor]
 	\label{eq:6}
-Sea $\mathcal{X}$ conjunto no vacíoy $\mathcal{H}$ un espacio de Hilbert
+Sea $\mathcal{X}$ conjunto no vacío y $\mathcal{H}$ un espacio de Hilbert
 de funciones $f: \mathcal{X} \rightarrow \mathbb{R}$. Se denomina a
 $\mathcal{H}$ espacio de Hilbert con kernel reproductor con producto punto
 $\left \langle \cdot ,  \cdot \right \rangle $ (y por tanto la norma
@@ -175,7 +175,7 @@ con las siguientes propiedades.
 
 Por definición (punto 2), un RKHS es un espacio formado por combinaciones lineales
 de funciones de la forma $k_{x}(\cdot)$ para todo $x \in \mathcal{X}$ y sus funciones
-limite (clausura). Esto último quiere decir, que toda función $f \in \mathcal{H}$
+límite (clausura). Esto último quiere decir, que toda función $f \in \mathcal{H}$
 puede ser aproximada a través de sucesiones de combinaciones lineales de elementos
 de la forma $k_{x}(\cdot)$, que claramente están únicamente determinados por el
 kernel $k(\cdot, \cdot)$.
@@ -202,7 +202,7 @@ Como todo funcional de la forma $k_x(\cdot) = k(x,\cdot) \in \mathcal{H}$ y este
   &=f(x )
 \end{align}
 
-Donde en la primera ecuación se utiliza la otrogonalidad $\psi_i \perp \psi_j$ en todo $i \neq j$. Posteriormente, se redefine el producto
+Donde en la primera ecuación se utiliza la ortogonalidad $\psi_i \perp \psi_j$ en todo $i \neq j$. Posteriormente, se redefine el producto
 interno en $L_2{(\mathcal{X})}$ de manera que $\langle \psi_j , \psi_l \rangle = \delta_{ij}/\lambda_j$, finalmente se tiene que
 \footnote{$\delta_{ij} = 1$ si $i = j$, y $\delta_{ij} = 0$ en caso
 contrario. Este objeto matemático se conoce como \textit{delta de
@@ -224,7 +224,7 @@ el RKHS correspondiente.
 
 Por definición para cada espacio RKHS existe una función kernel, por el argumento
 anterior, se puede intuir la existencia de cierta relación de equivalencia entre
-los kernels que describen a un espacio RKHS. La respues a tal inquietud es aún más
+los kernels que describen a un espacio RKHS. La respuesta tal inquietud es aún más
 fuerte, pues establece que a cada RKHS corresponde una único kernel \cite{Aro1950}.
 
 \begin{theorem}[Moore-Aronszajn]
@@ -294,7 +294,7 @@ k \left(\bm{x},\bm{x'} \right)= \exp \left( - \frac{ \| \bm{x} -\bm{x'} \| ^2  }
 \end{equation}
 
 donde $\sigma$ Se conoce como \textbf{ancho de banda}. Las funciones
-del tipo (\ref{funcionradialbase}), se conocen como \textbf{funciones de base radial}, y se caracterizan por depender unicamente de la diferencia entre los puntos que opera, es decir, $k(\bm{x},\bm{x}') = k(\bm{x} - \bm{x}')$. Por este motivo el kernel de la ecuación
+del tipo (\ref{funcionradialbase}), se conocen como \textbf{funciones de base radial}, y se caracterizan por depender únicamente de la diferencia entre los puntos que opera, es decir, $k(\bm{x},\bm{x}') = k(\bm{x} - \bm{x}')$. Por este motivo el kernel de la ecuación
 (\ref{funcionradialbase}) se conoce como kernel RBF (Radial Basis
 Function).
 
@@ -349,7 +349,7 @@ donde $\rho>0$ y $p(\bm{x} | \bm{x_i})$ se aproxima por $p(\bm{x} |
 un parámetro estimado obtenido usando el dato $\bm{x_i}$. Este kernel
 es llamado \textbf{kernel producto de probabilidad} \cite{Jebara2004}.
 
-El modelo ajustado será usado para ver cuan similar son los objetos que
+El modelo ajustado será usado para ver cuán similar son los objetos que
 se operan. En particular, si se ajusta el modelo a $\bm{x_i}$ se desea
 que este sea capaz de indicar cuando otro dato $\bm{x_j}$ es similar.
 Si a modo de ejemplo, se supone $p(\bm{x}| \bm{\theta)}=\mathcal{N} (\mu , \sigma^2 \bm{I})$ donde $\sigma^2$ es fijo. Con $\rho=1$ y
@@ -382,13 +382,13 @@ corresponde esencialmente a la matriz Hessiana:
 \bm{F}= \nabla \nabla \log p(\bm{x} | \theta )|_{\widehat{\theta}}
 \end{equation*}
 
-Debido a que el estimador $\widehat{\theta}$ se obitne en función de
+Debido a que el estimador $\widehat{\theta}$ se obtiene en función de
 todos los datos, se tiene que similitud de $\bm{x}$ y $\bm{x'}$ es
 por tanto calculada usando todos los datos.
 
 Si $\bm{g}(\bm{x})$ es la dirección en la cual los datos $\bm{x}$
 condicionan el valor de $\widehat{\theta})$ al momento de maximizar la
-verosimilitud. Se desea considerar como similares a los puntos $\bm{x}$ y $\bm{x'}$ si las direcciones para el gradiente que condicionan la verosimilitud en $\theta$ son similares entre si.
+verosimilitud. Se desea considerar como similares a los puntos $\bm{x}$ y $\bm{x'}$ si las direcciones para el gradiente que condicionan la verosimilitud en $\theta$ son similares entre sí.
 
 \section{Kernels en modelos lineales generalizados}
 
@@ -410,7 +410,7 @@ enfoque, no se requiere que el kernel sea Mercer.
 
 Se puede usar el vector de características kernelizado entrenar un
 modelo de regresión logística definiendo $p(y| \bm{x} , \theta)= Ber(\bm{w}^\top \phi(\bm{x}) )$. Esta formulación permite definir
-bordes de descición no lineales de manera sencilla a traves de la elección del kernel.
+bordes de decisión no lineales de manera sencilla a través de la elección del kernel.
 
 De la misma forma, es posible usar el vector de características
 anterior para entrenar un modelo de regresión lineal al definir
@@ -418,13 +418,13 @@ $p(y| \bm{x} , \theta)= \mathcal{N} ( \bm{w}^\top \phi(\bm{x}) , \sigma^2 )$.
 
 \subsection{LIVMs, RVMs y Maquinas de vectores sparse}
 
-Al formular modelos basados en Maquinas de kernel, no se especifica la
-manera optima para la obtención de centroides $\mu_k$. Un enfoque
+Al formular modelos basados en Máquinas de kernel, no se especifica la
+manera óptima para la obtención de centroides $\mu_k$. Un enfoque
 consiste en encontrar clusters en los datos y luego asignarlos como
-prototipos. Sim embargo, no se puede garantizar que a través de esta
+prototipos. Sin embargo, no se puede garantizar que a través de esta
 búsqueda se encuentren representaciones convenientes para la
 predicción. A esto se suma la elección del número de clusters, que
-tampoco esta especificada. Otro enfoque es considerar hacer cada
+tampoco está especificada. Otro enfoque es considerar hacer cada
 elemento $\bm{x_i}$ como un prototipo, de esta forma se obtiene
 \begin{equation*}
 \bm{\phi}(\bm{x})=[ k( \bm{x} , \bm{x}_1),..., k (\bm{x} , \bm{x}_N)]
@@ -437,10 +437,10 @@ solo se resuelve el problema referente a la alta cantidad de
 parámetros, sino que también la dispersión inducida en el vector de
 características permite escoger aquellos puntos más relevantes,
 permitiendo seleccionar un subconjunto de los datos para predecir. Los
-modelos que hace uso de este principio se denominan \textbf{Maquinas de vectores sparse}.
+modelos que hace uso de este principio se denominan \textbf{Máquinas de vectores sparse}.
 
 En tal sentido, la elección más natural al momento de inducir
-dispersión es el uso de regularización $l_1$ \cite{Kri2005}. A la maquina de vectores resultante del uso de este regularizador para inducir dispersión se le denominará \textbf{LIVM}  (Maquina de vectores regularizada $l_1$) . Análogamente, el uso de  un regularizador $l_2$  da lugar a \textbf{L2VM} (máquina de vectores $l_2$-regularizada), en este último modelo no se induce dispersión (debido al tipo de regularización).
+dispersión es el uso de regularización $l_1$ \cite{Kri2005}. A la máquina de vectores resultante del uso de este regularizador para inducir dispersión se le denominará \textbf{LIVM}  (Maquina de vectores regularizada $l_1$) . Análogamente, el uso de  un regularizador $l_2$  da lugar a \textbf{L2VM} (máquina de vectores $l_2$-regularizada), en este último modelo no se induce dispersión (debido al tipo de regularización).
 
 Es también posible implementar el método ARD para inducir dispersión,
 el método resultante se denomina \textbf{Máquina de vectores de relevancia} o \textbf{RVM} \cite{Tip2001}.
@@ -448,7 +448,7 @@ el método resultante se denomina \textbf{Máquina de vectores de relevancia} o 
 Otra manera maquina de vector sparse los lo modelos conocidos como
 \textbf{máquinas de vectores de soporte} (SVM)
 
-\subsection{Maquinas de vectores de soporte (SVM)}
+\subsection{Máquinas de vectores de soporte (SVM)}
 
 Este m\'etodo se desarroll\'o para resolver problemas de
 clasificaci\'on y aproximaci\'on est\'atica de funciones \cite{Cor1995}
@@ -461,7 +461,7 @@ f(x)=w^T \varphi(x) + b
 \label{eq:1_svm}
 \end{equation}
 En este contexto, la aplicaci\'on $ \varphi: \mathbb{R}^n \rightarrow
-\mathbb{R}^{N_{\mathcal{H}}} $ corresponde la transformaci\'on de caracterisitcas
+\mathbb{R}^{N_{\mathcal{H}}} $ corresponde la transformaci\'on de características
 sobre los datos. El parametro $ w \in \mathbb{R}^{N_{\mathcal{H}}} $ corresponde a al vector de pesos asociado a la construcci\'on del modelo y cuya dimensi\'on depende directamente de $ \varphi $, pudiendo ser infinito dimensional.
 
 Se busca estimar minimizando el riesgo emp\'irico $ \textbf{R}_{emp}$  definido por:
@@ -470,7 +470,7 @@ Se busca estimar minimizando el riesgo emp\'irico $ \textbf{R}_{emp}$  definido 
 \textbf{R}_{emp}={\frac{1}{N} \sum_{i=1}^{N} \left| {y_i -w^T \varphi{(x_i)}-b} \right|_{\varepsilon}}
 \end{equation}
 
-Donde se emplea la funci\'on de perdida $ \varepsilon $-insensible de Vapnik, definida por:
+Donde se emplea la funci\'on de pérdida $ \varepsilon $-insensible de Vapnik, definida por:
 
 \begin{equation}
 \left| {y - f(x)} \right|_{\varepsilon}=
@@ -582,12 +582,12 @@ resultados obtenidos anteriormente, es posible reformular por medio de
 la herramienta conocida como el \textbf{truco del kernel}
 \cite{Hof2008}.
 
-El truco del kernel consiste en reemplazar el calculo de productos
+El truco del kernel consiste en reemplazar el cálculo de productos
 internos por una función kernel haciendo uso del resultado
 (\ref{eq:3}). En el caso de la formulación SVM, es posible reemplazar
 $\varphi(x_i)^T\varphi(x_j)$ por una función kernel de la forma
 $k(x_i,x_j) = \varphi(x_i)^T\varphi(x_j)$. La estructura de este kernel
-no se conoce a piori, esto pues la definición de $\varphi(\cdot)$ fue
+no se conoce a priori, esto pues la definición de $\varphi(\cdot)$ fue
 netamente teórica. Sin embargo, se sabe que su producto interno se
 puede representar por un kernel. La idea detrás de este método
 consiste en seleccionar un kernel de manera tal que las funciones base
@@ -616,10 +616,10 @@ f(x)=\sum_{i=1}^{N}(\alpha_i-\alpha^*_i)k(x_i,x)+b
 \end{equation}
 
 \subsection{LS-SVM}
-Una variante del método SVM es su versión basada en minimos cuadrados,
+Una variante del método SVM es su versión basada en mínimos cuadrados,
 la cual se formula como una alternativa más eficiente\cite{Suy2002}.
 
-Su formulaci\'on es similar a la expuesta en \ref{pr:problema_holgura}, considerando la formula habitual de regresi\'on presentada en (\ref{eq:1_svm}):
+Su formulaci\'on es similar a la expuesta en \ref{pr:problema_holgura}, considerando la fórmula habitual de regresi\'on presentada en (\ref{eq:1_svm}):
 \begin{equation}
 \label{pr:LSSVM_simple}
 \left \lbrack{
@@ -629,7 +629,7 @@ Su formulaci\'on es similar a la expuesta en \ref{pr:problema_holgura}, consider
 	\end{aligned}
 } \right \rbrack
 \end{equation}
-En esta nueva formulaci\'on, los t\'erminos de error $ e_i $ juegan un papel similar al de las variables de holgura $ \xi_i,~\xi^*_i $ en (\ref{pr:problema_holgura}), con excepci\'on de que la funci\'on de perdida que se aplica a estas variables es ahora cuadr\'atica. Se comienza entonces por establecer el Lagrangiano:
+En esta nueva formulaci\'on, los t\'erminos de error $ e_i $ juegan un papel similar al de las variables de holgura $ \xi_i,~\xi^*_i $ en (\ref{pr:problema_holgura}), con excepci\'on de que la funci\'on de pérdida que se aplica a estas variables es ahora cuadr\'atica. Se comienza entonces por establecer el Lagrangiano:
 
 \begin{equation}
 \label{eq:Lagrange_LS}
@@ -650,7 +650,7 @@ Donde los coeficientes $ \alpha_i $ son los multiplicadores de Lagrange. Las con
 \right.
 \end{equation}
 
-Al despejar $ w $, $ e_i $ y reemplazar en la ultima igualdad se obtiene:
+Al despejar $ w $, $ e_i $ y reemplazar en la última igualdad se obtiene:
 
 \begin{equation}
 \label{eq:pre_matriz}
@@ -730,7 +730,7 @@ donde
 d(i,i') \triangleq  \| \bm{x_i} - \bm{x_i'} \|_{2}^{2}
 \end{equation*}
 
-Esto toma $ O(n_k ^2)$ trabajo por cluster, mientras K-medias toma $O(n_k D)$ para actualizar cada cluster. En el algoritmo (\ref{alg:5}) se aprecia la estrucutra del método. Al calular el medoide más cercano a la clase, el problema se transforma en \textbf{clasificación medoide mas cercano}\cite{Has2009}
+Esto toma $ O(n_k ^2)$ trabajo por cluster, mientras K-medias toma $O(n_k D)$ para actualizar cada cluster. En el algoritmo (\ref{alg:5}) se aprecia la estructura del método. Al calular el medoide más cercano a la clase, el problema se transforma en \textbf{clasificación medoide mas cercano}\cite{Has2009}
 Este algoritmo puede ser kernelizado usando Ecuación (\ref{Eq:vecinomascercano}) para reemplazar la distancia $ d(i,i')$ .
 
 \begin{algorithm}
@@ -790,7 +790,7 @@ resume en el algoritmo \ref{alg:9}.
 
 \begin{algorithm}
 \DontPrintSemicolon
-\KwIn{$\bm{K}$ de tamaño $N \times N$, $\bm{K}_{*}$ de tamaño $N_{*}\times N$, numero de dimenciones latentes L}
+\KwIn{$\bm{K}$ de tamaño $N \times N$, $\bm{K}_{*}$ de tamaño $N_{*}\times N$, número de dimensiones latentes L}
 $\bm{O} = \mathbf { 1 } _{N} \mathbf { 1 }_{N}^T /N$ \;
 
 $\tilde{ \mathbf { K } } = \bm{K} - \bm{O}\bm{K} - \bm{K}\bm{O} + \bm{O}\bm{K}\bm{O}$\;
@@ -812,7 +812,7 @@ $Z = \tilde{ \mathbf { K } } \bm{V}(:,1:L)$;
 \section{Kernels para construir modelos generativos}
 
 Otra case kernels, conocidos como kernels de suavizado, permiten
-caracterizar estimaciones no paramétricas de desidades. Lo cual puede
+caracterizar estimaciones no paramétricas de densidades. Lo cual puede
 ser utilizado para generar estimaciones de densidades de manera no
 supervisada, así como también para crear modelos generativos tanto para
 regresión como para clasificación.
@@ -840,7 +840,7 @@ No obstante, en el caso del kernel gaussiano, el kernel de suavizado pasa a ser:
 \begin{equation*}
 k _ { h } ( \mathbf { x } ) = \frac { 1 } { h ^ { D } ( 2 \pi ) ^ { D / 2 } } \prod _ { j = 1 } ^ { D } \exp \left( - \frac { 1 } { 2 h ^ { 2 } } x _ { j } ^ { 2 } \right)
 \end{equation*}
-Si bien los kernels de la familia gausiana poseen propiedades que permiten simplicar el gasto computacional, su soporte no es acotado, por lo que en modelos reales carece de expresividad. Una alternatica a esto es el \textbf{kernel Epanechnikov}, el cual posee soporte compacto y esta definido por:
+Si bien los kernels de la familia gaussiana poseen propiedades que permiten simplificar el gasto computacional, su soporte no es acotado, por lo que en modelos reales carece de expresividad. Una alternativa a esto es el \textbf{kernel Epanechnikov}, el cual posee soporte compacto y está definido por:
 \begin{equation*}
 k ( x ) \triangleq \frac { 3 } { 4 } \left( 1 - x ^ { 2 } \right) \mathbb { I } ( | x | \leq 1 )
 \end{equation*}
@@ -871,7 +871,7 @@ Modelo conocido como estimador \textbf{Parzen window density} , o \textbf{estima
 
 \subsection{De KDE a KNN}
 
-Se puede usar KDE para definir las clases de densidades condicionales en un clasificador generativo.  Esto proporciona una derivación  alternativa  del clasificador KNN. En KDE con un kernel  boxcar se fijara el ancho de banda y se contará cuantos puntos caen dentro del hyper cubo centrado sobre cada dato. Si se modela el ancho de banda $h$ como un parámetro de modelo, se permite que el ancho de banda o volumen sea distinto para cada dato. Específicamente, se aumentará el volumen alrededor de $\bm{x}$ hasta encontrar $K$ datos, sin importar su clase. Sea el volumen resultante $V$ con $V(x)$ y $N_c(x)$ ejemplos de clase $c$ en tal volumen. Luego es posible estimar la densidad condicional la de clase de como sigue:
+Se puede usar KDE para definir las clases de densidades condicionales en un clasificador generativo.  Esto proporciona una derivación  alternativa  del clasificador KNN. En KDE con un kernel boxcar se fijará el ancho de banda y se contará cuantos puntos caen dentro del hípercubo centrado sobre cada dato. Si se modela el ancho de banda $h$ como un parámetro de modelo, se permite que el ancho de banda o volumen sea distinto para cada dato. Específicamente, se aumentará el volumen alrededor de $\bm{x}$ hasta encontrar $K$ datos, sin importar su clase. Sea el volumen resultante $V$ con $V(x)$ y $N_c(x)$ ejemplos de clase $c$ en tal volumen. Luego es posible estimar la densidad condicional la de clase de como sigue:
 \begin{equation*}
 p ( \mathbf { x } | y = c , \mathcal { D } ) = \frac { N _ { c } ( \mathbf { x } ) } { N _ { c } V ( \mathbf { x } ) }
 \end{equation*}
@@ -879,7 +879,7 @@ Donde $N_c$ es el número total de ejemplos en la clase $c$ en aquel conjunto de
 \begin{equation*}
 p ( y = c | \mathcal { D } ) = \frac { N _ { c } } { N }
 \end{equation*}
-Por lo tanto, la posterior de clase esta dada por:
+Por lo tanto, la posterior de clase está dada por:
 \begin{equation*}
 p ( y = c | \mathbf { x } , \mathcal { D } ) = \frac { \frac { N _ { c } ( \mathbf { x } ) } { N _ { c }V ( \mathbf { x } ) } \frac { N _ { c } } { N } } { \sum _ { c ^ { \prime } } \frac { N _ { c '}  ( \mathbf { x } ) } { { N _ { c ^ { \prime } }  V( \mathbf { x } ) }} \frac { N _ { c ^ { \prime } } } { N }  } = \frac { N _ { c } ( \mathbf { x } ) } { \sum _ { c ^ { \prime } } N _ { c ^{ \prime }  } ( \mathbf { x } ) } = \frac { N _ { c } ( \mathbf { x } ) } { K }
 \end{equation*}
@@ -909,14 +909,14 @@ Se puede reescribir el resultado anterior de la siguiente manera:
 \left.\begin{aligned} f ( \mathbf { x } ) & = \sum _ { i = 1 } ^ { N } w _ { i } ( \mathbf { x } ) y _ { i } \\ w _ { i } ( \mathbf { x } ) & \triangleq \frac { k _ { h } \left( \mathbf { x } - \mathbf { x } _ { i } \right) } { \sum _ { i ^ { \prime } = 1 } ^ { N } k _ { h } \left( \mathbf { x } - \mathbf { x } _ { i ^ { \prime } } \right) } \end{aligned} \right.
 \end{equation*}
 
-La prediccón es por tanto una suma ponderada de los resultados de los datos de entrenamiento, donde los pesos dependen de que tan similar es $\mathbf{ x }$ de los puntos de entrenamientos almacenados. Este método es llamado \textbf{regresión kernel}, \textbf{kernel suavizado} o el modelo \textbf{Nadaraya-Watson}.
+La predicción es por tanto una suma ponderada de los resultados de los datos de entrenamiento, donde los pesos dependen de qué tan similar es $\mathbf{ x }$ de los puntos de entrenamientos almacenados. Este método es llamado \textbf{regresión kernel}, \textbf{kernel suavizado} o el modelo \textbf{Nadaraya-Watson}.
 
 \subsection{Regresión localmente ponderada}
 Si se define $k _ { h } \left( \mathbf { x } - \mathbf { x } _ { i } \right) = k \left( \mathbf { x } , \mathbf { x } _ { i } \right)$ se puede reescribir la predicción hecha mediante regresiòn kernel como sigue
 \begin{equation*}
 \hat { f } \left( \mathbf { x } _ { * } \right) = \sum _ { i = 1 } ^ { N } y _ { i } \frac { k \left( \mathbf { x } _ { * } , \mathbf { x } _ { i } \right) } { \sum _ { i ^ { \prime } = 1 } ^ { N } k \left( \mathbf { x } _ { * } , \mathbf { x } _ { i ^ { \prime } } \right) }
 \end{equation*}
-Si en este caso $k \left( \mathbf { x } , \mathbf { x } _ { i } \right)$ fuera un kernel suavizado, se podrìa ignorar el termino normalización, en tal caso:
+Si en este caso $k \left( \mathbf { x } , \mathbf { x } _ { i } \right)$ fuera un kernel suavizado, se podría ignorar el término normalización, en tal caso:
 \begin{equation*}
 \hat { f } \left( \mathbf { x } _ { * } \right) = \sum _ { i = 1 } ^ { N } y _ { i } k \left( \mathbf { x } _ { * } , \mathbf { x } _ { i } \right)
 \end{equation*}
@@ -924,7 +924,7 @@ Este modelo consiste esencialmente en una función fija localmente constante. Es
 \begin{equation*}
 \min _ { \beta \left( \mathbf { x } _ { * } \right) } \sum _ { i = 1 } ^ { N } k \left( \mathbf { x } _ { * } , \mathbf { x } _ { i } \right) \left[ y _ { i } - \boldsymbol { \beta } \left( \mathbf { x } _ { * } \right) ^ { T } \boldsymbol { \phi } \left( \mathbf { x } _ { i } \right) \right] ^ { 2 }
 \end{equation*}
-donde $\phi ( \mathbf { x } ) = [ 1 , \mathbf { x } ]$. Esto es llamado \textbf{regresión ponderada localmente}. Un ejemplo de tal metodo es \textbf{LOESS} o \textbf{LOWES} que significa para  “locally-weighted scatterplot smoothing”.
+donde $\phi ( \mathbf { x } ) = [ 1 , \mathbf { x } ]$. Esto es llamado \textbf{regresión ponderada localmente}. Un ejemplo de tal método es \textbf{LOESS} o \textbf{LOWES} que significa para  “locally-weighted scatterplot smoothing”.
 Se puede calcular el parámetro $\boldsymbol { \beta } \left( \mathbf { x } _ { * } \right)$ para cada caso de test resolviendo el siguiente problema de mínimos cuadrados ponderados:
 \begin{equation*}
 \boldsymbol { \beta } \left( \mathbf { x } _ { * } \right) = \left( \mathbf { \Phi } ^ { T } \mathbf { D } \left( \mathbf { x } _ { * } \right) \mathbf { \Phi } \right) ^ { - 1 } \mathbf { \Phi } ^ { T } \mathbf { D } \left( \mathbf { x } _ { * } \right) \mathbf { y }

--- a/capitulos/cap4.tex
+++ b/capitulos/cap4.tex
@@ -3,15 +3,15 @@
 
 \chapter{Discusión}
 
-En este reporte se busco compilar ciertos tópicos de interés
-pertenecientes al aprendizaje automático. En especifico se abordaron
+En este reporte se buscó compilar ciertos tópicos de interés
+pertenecientes al aprendizaje automático. En específico se abordaron
 temas referentes a modelos gráficos probabilísticos, haciendo hincapié
 en modelos gráficos dirigidos. En este contexto, el paso natural es
 expandir dicha sección para tratar temas relacionados a modelos
 gráficos probabilísticos no dirigidos y grafos factor. En segunda
 instancia se abordaron métodos de inferencia aproximada basados tanto
 en MCMC como en inferencia variacional con enfoque en el algoritmo
-CAVI. En cuanto a la tercera y ultima sección, se revisaron las bases y
+CAVI. En cuanto a la tercera y última sección, se revisaron las bases y
 propiedades referentes al los métodos basados en kernel.
 
 Para futuras versiones de esta monografía, se propone desarrollar

--- a/main.tex
+++ b/main.tex
@@ -6,6 +6,7 @@
 
 % Librerias Personales
 \usepackage{framed}
+\usepackage[hidelinks]{hyperref}
 \usepackage{subfiles} % Documento modular
 \usepackage[utf8]{inputenc} % Acentos simples
 \usepackage{bm} % Simbolos matematicos en negrita

--- a/misc/preface.tex
+++ b/misc/preface.tex
@@ -6,7 +6,7 @@
 % This is a data file input by chapter.tex.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\chapter*{Preface}
+\chapter*{Prólogo}
 
 El presente trabajo reúne resultados referentes al aprendizaje automático,
 y busca servir como material de apoyo en el estudio de esta disciplina. En esta versión se estudian de manera autocontenida tópicos sobre modelos


### PR DESCRIPTION
Hola, hice un par de cambios chicos:
- Agregué el paquete hyperref para que la tabla de contenidos y otras referencias puedan ser clickeables
- Cambié preface por prólogo para consistencia de lenguaje
- Arreglé vairos errores chicos de ortografía. Quizás sea bueno usar _hyphens_ para dejar las palabras como "híper-parámetros", "híper-cubo", "no-períodico", etc.